### PR TITLE
Add option for environment variables

### DIFF
--- a/checks.d/pm2.py
+++ b/checks.d/pm2.py
@@ -5,8 +5,8 @@ import json
 from checks import AgentCheck
 
 
-def load_json(command):
-    p = subprocess.Popen(command, stdout=subprocess.PIPE)
+def load_json(command, environment):
+    p = subprocess.Popen(command, env=environment, stdout=subprocess.PIPE)
     out = p.communicate()[0]
     return json.loads(out)
 
@@ -15,7 +15,7 @@ class Pm2(AgentCheck):
 
     def check(self, instance):
 
-        for instance in load_json(instance['command'].split(' ')):
+        for instance in load_json(instance['command'].split(' '), instance.get('environment')):
             node_app_instance = instance['pm2_env']['NODE_APP_INSTANCE']
 
             tags = ["node_id:%s" % node_app_instance]


### PR DESCRIPTION
This PR allows passing environment variables to the `command` argument.

Example:

```yaml
instances:
 - command: '/bin/pm2 jlist'
   environment:
     HOME: '/home/foobar'
```